### PR TITLE
Added build check for duplicate EVR in spec file 

### DIFF
--- a/railsbuild-build
+++ b/railsbuild-build
@@ -22,6 +22,18 @@ do
       continue
     fi
 
+    # Check changelog in spec file for same EVR
+    if [ -n "$(
+      sed -n '/^%changelog/,$p' rubygem-$gem.spec \
+        | grep -E " [0-9]+\:[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+$" \
+        | head -n 2 | rev | cut -d' ' -f1 \
+        | sort | uniq -c | grep -vE "^[ ]*1 "
+      )" ]; then
+        echo "= FAIL ======"
+        echo "$gem: same EVR in changelog already exists"
+        exit 1
+    fi
+
     rm *.src.rpm
     fedpkg scratch-build --srpm
 


### PR DESCRIPTION
Checks changelog in spec file for entry with same EVR.
Prevents running update for same epoch-version-release.
Version check is already done in railsbuild-update-pkgs, but it does not prevent user running ./railsbuild-build directly on same EVR.
